### PR TITLE
made toast fixed, so it stays in bottom right when you scroll.

### DIFF
--- a/src/pwa-update.ts
+++ b/src/pwa-update.ts
@@ -28,7 +28,7 @@ export class pwaupdate extends LitElement {
       }
 
       #updateToast {
-        position: absolute;
+        position: fixed;
         bottom: 16px;
         right: 16px;
         background: var(--toast-background);
@@ -46,7 +46,7 @@ export class pwaupdate extends LitElement {
       }
 
       #storageToast {
-        position: absolute;
+        position: fixed;
         bottom: 16px;
         right: 16px;
         background: var(--toast-background);


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The toast that previously told the user the app needed an update was position absolute. This means that when the user scrolls, the toast doesn't stay in the corner. 

## Describe the new behavior?
I changed it to fixed to keep the toast in the bottom right.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
