### PR TITLE
Ensure that the toast fits onto the screen

### DIFF
--- a/src/pwa-update.ts
+++ b/src/pwa-update.ts
@@ -38,6 +38,7 @@ export class pwaupdate extends LitElement implements PWAUpdateComponent {
         align-items: center;
         justify-content: space-between;
         min-width: 22em;
+        max-width: calc(100vw - 16px);
         font-weight: 600;
 
         animation-name: fadein;
@@ -53,6 +54,7 @@ export class pwaupdate extends LitElement implements PWAUpdateComponent {
         padding: 1em;
         border-radius: 4px;
         display: flex;
+        max-width: calc(100vw - 16px);
         flex-direction: column;
         align-items: flex-end;
 


### PR DESCRIPTION
Sometimes it goes over the edge on smaller phones.

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
On smaller phones, the toast notification will overflow into the left edge of the screen since the toast is wider than the screen size.

## Describe the new behavior?
Now, the toast should restrict it's size to the viewport width, which should rarely be needed except for with small phones.

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
